### PR TITLE
Pin mysql docker image

### DIFF
--- a/benchmarks/tpcc/my.cnf.d/my.cnf
+++ b/benchmarks/tpcc/my.cnf.d/my.cnf
@@ -13,5 +13,5 @@ max_connections=1024
 innodb_flush_method = O_DIRECT
 
 innodb_buffer_pool_size = 10G
-mysql_native_password = ON
+# mysql_native_password = ON
 disable_log_bin

--- a/benchmarks/tpcc/sysbench-tpcc.sh
+++ b/benchmarks/tpcc/sysbench-tpcc.sh
@@ -39,7 +39,7 @@ MYSQL_ROOT_PASSWORD=my-secret-pw                        # Root Users Password
 MYSQL_START_PORT=3333                                   # Host Port number for the first instance. Additional instances will increment by 1 for each instance 3306..3307..3308..
 MYSQL_DATA_DIR=/data                                    # Base directory for the MySQL Data Directory on the host
 MYSQL_CONF=${SCRIPTDIR}/my.cnf.d/my.cnf                 # Location of the my.cnf file(s)
-MySQLDockerImgTag="docker.io/library/mysql:latest"      # MySQL Version. Get the Docker Tag ID from https://hub.docker.com/_/mysql
+MySQLDockerImgTag="docker.io/library/mysql:8.0.39"      # MySQL Version. Get the Docker Tag ID from https://hub.docker.com/_/mysql
 
 
 # === Sysbench Variables ===


### PR DESCRIPTION
Pin the mysql docker image to version 8.0.39.
Disable mysql_native_password in the my.cnf file in line with the expectations of version 8.0.39.