### PR TITLE
[TPCC] Waiting for MYSQL container to be healthy before starting benchmark

### DIFF
--- a/benchmarks/tpcc/sysbench-tpcc.sh
+++ b/benchmarks/tpcc/sysbench-tpcc.sh
@@ -1128,8 +1128,8 @@ function delete_container_data()
 {
     for i in $(seq 1 ${PM_INSTANCES});
     do
-        info_msg "Removing mysql${i} data at $MYSQL_DATA_DIR/mysql${i}"
-        sudo rm -rf $MYSQL_DATA_DIR/mysql${i}
+        info_msg "Removing mysql${i} data at ${MYSQL_DATA_DIR}/mysql${i}"
+        sudo rm -rf ${MYSQL_DATA_DIR}/mysql${i}
     done
 }
 
@@ -1686,6 +1686,7 @@ for function in "${functions[@]}"; do
         delete_container_data
 
         error_msg "An error occurred in '$function'. Exiting."
+        error_msg "See container logs at '${OUTPUT_PATH}/${OUTPUT_PREFIX}mysql.*.log' for details"
         break
     fi
 done


### PR DESCRIPTION
# sysbench bash script now checks for healthy container

1. Initial setup -- first pane is what is going to be ran, second is `podman stats`, third is a command ready to check that the `mysql1` container is running before killing it

![image](https://github.com/user-attachments/assets/30d80a9b-ca3f-4c2d-bbb9-b09659ae1b74)

2. During startup -- Benchmark script has started, and `podman stats` is showing that both sysbench and mysql containers are running. The last pane confirms that `mysql` is running.

![image](https://github.com/user-attachments/assets/c2368c61-c89e-42b7-a771-d0e4e7660a74)

3. `mysql1` container killed mid-startup -- The bottom pane has the kill command, and the logs show that we've stopped the sysbench script mid startup to prevent further painpoints.

![image](https://github.com/user-attachments/assets/f165158f-e0da-4ad7-acea-07f6c4ee2506)

# Why check?

This screenshot shows what happens without this implementation. Although the `mysql1` container no longer exists, sysbench is still trying to check for the logs.
![image](https://github.com/user-attachments/assets/a841d120-a5f4-4e4f-a024-7b04bde792ca)
