### PR TITLE
Unify the docker usage

### DIFF
--- a/benchmarks/IntelMLC/README.md
+++ b/benchmarks/IntelMLC/README.md
@@ -63,8 +63,8 @@ The `utils` directory has some useful scripts to help process the results faster
 
 ```bash
 // Install Python3 and PIP
-Ubuntu/Debian: $ sudo apt install pythong3 pip
-RHEL/Fedora/CentOS: $ sudo dnf install pythong3 pip
+Ubuntu/Debian: $ sudo apt install python3 pip
+RHEL/Fedora/CentOS: $ sudo dnf install python3 pip
 
 // Install the requirements for the parsing scripts
 $ pip install -r requirements.txt

--- a/benchmarks/Qdrant-Synthetic/README.md
+++ b/benchmarks/Qdrant-Synthetic/README.md
@@ -18,7 +18,11 @@ This benchmark allows users to configure various parameters such as the number o
    git clone https://github.com/your-username/qdrant-benchmark.git
    cd qdrant-benchmark
    ```
-3. Run the benchmark using the provided script.
+3.  Install python modules:
+   ```bash
+   pip3 install qdrant_client tqdm
+   ```
+4. Run the benchmark using the provided script.
 
 ## Usage
 

--- a/benchmarks/cloudsuite3/graph-analytics/README.md
+++ b/benchmarks/cloudsuite3/graph-analytics/README.md
@@ -2,9 +2,7 @@
 
 ## Setup
 
-The run script will automatically pull down the default graph analytics image.
-
-If you need an interleave-image, see "Creating interleave images".
+Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 ## Running the test
 
@@ -18,10 +16,10 @@ Some options can be overidden
 Usage: ./run.sh [options]
 Options:
   -h             : Display this help message.
-  -p             : Test requires privilege (interleave container)
+  -p             : Set in-container numactl mempolicy
   -c  <integer>  : CPU NUMA node to bind to
   -m  <int,...>  : Memory NUMA nodes to allow
-  -w  <string>   : Container name. Default: cloudsuite3/graph-analytics
+  -w  <string>   : Container name. Default: cxlbench-graph-analytics
   -d  <integer>  : Set the driver memory. Default:64g
   -e  <integer>  : Set the executor memory. Default:64g
   -o  <string>   : Output file to concatenate results to
@@ -43,48 +41,12 @@ Included is a sample test plan for a CXL device on NUMA Node 2.
 # Bind the workload to NUMA 0
 ./run.sh -c 0 -m 0 -n "cpu=0 mem=0"
 
-# Interleave the workload between Node 0 and Node 2
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --interleave=0,2" -p -w graph-interleave
+# Interleave the workload between Node 0 and Node 2 with weighted interleave
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --weighted-interleave=0,2" -p "--weighted-interleave=0,2"
 
 # Primarily use NODE 2, but allow non-movable allocations to NODE 0
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p -w graph-prefer2
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p "--preferred=2"
 ```
-
-# NUMACtl Images 
-
-## Creating interleave images
-
-Docker does not allow enabling interleave from outside the container, so software in the container must be changed to invoke numactl --interleave.  These are directions to modify the comatiner image and save a local copy of the modified container image.
-
-Note that these directions assume your interleave settings will be "--interleave=0,2" (NUMA nodes 0 and 2).  You should change this to match your desired settings.
-
-In one terminal:
-1. docker run -it --entrypoint="/bin/bash" cloudsuite3/graph-analytics
-2. you'll now be in a copy of the docker container at the bash prompt
-3. apt update
-4. apt install vim numactl
-5. vim /benchmarks/run\_benchmark.sh
-6. change "exec ${SPARK\_HOME}" to "exec numactl --interleave=0,2 ${SPARK\_HOME}"
-7. save and close the document.  do not exit the container yet.
-
-In another terminal:
-1. docker container list
-2. get the container ID for the in-memory-analytics container (e.g. c7b06ce106a0)
-3. docker container commit c7b06ce106a0 graph-interleave
-
-## Create Preferred Node images
-
-Mode CXL memory is onlined as ZONE\_MOVABLE, as a result attempting to run this container 100% out of CXL will probably fail because the kernel will require some ZONE\_NORMAL memory.
-
-To *prefer* node 2 for workload data, follow the interleave image direction, but use --preferred=2 instead of --interleave=0,2.  Then save this image as graph-prefer2.
-
-## Running interleave image
-
-Interleave containers require privilege to run.  To do this, use the -i command to mark the test an interleave test and use -w to replace the container name
-
-Example:
-
-./run -p -c 0 -m 0,2 -w graph-interleave
 
 # Tiering
 

--- a/benchmarks/cloudsuite3/graph-analytics/README.md
+++ b/benchmarks/cloudsuite3/graph-analytics/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/cloudsuite3/graph-analytics/README.md
+++ b/benchmarks/cloudsuite3/graph-analytics/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/cloudsuite3/graph-analytics/README.md
+++ b/benchmarks/cloudsuite3/graph-analytics/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docker image used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/cloudsuite3/graph-analytics/run.sh
+++ b/benchmarks/cloudsuite3/graph-analytics/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi
@@ -134,7 +137,6 @@ mkdir -p results
 
 docker create --name graph-data cloudsuite3/twitter-dataset-graph
 
-echo "Test: docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from graph-data $CONTAINER $DMEM $EMEM"
 start_time=$(date +%s%N)
 docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from graph-data $CONTAINER $DMEM $EMEM > results/raw_results.txt
 end_time=$(date +%s%N)

--- a/benchmarks/cloudsuite3/graph-analytics/run.sh
+++ b/benchmarks/cloudsuite3/graph-analytics/run.sh
@@ -8,7 +8,7 @@ CPUSETS_CPU=""
 CPUSETS_MEM=""
 DMEM="--driver-memory 64g"
 EMEM="--executor-memory 64g"
-CONTAINER="cloudsuite3/graph-analytics"
+CONTAINER="cxlbench-graph-analytics"
 PRIVILEGED=""
 RESULTS="results.txt"
 NOTE="Default settings"
@@ -19,10 +19,10 @@ function display_help {
 	echo "Usage: $0 [options]"
 	echo "Options:"
 	echo "  -h             : Display this help message."
-	echo "  -p             : Test requires privilege (interleave container)."
+	echo "  -p             : Set in-container numactl mempolicy"
 	echo "  -c  <integer>  : CPU NUMA node to bind to"
 	echo "  -m  <int,...>  : Memory NUMA nodes to allow"
-	echo "  -w  <string>   : Container name. Default: cloudsuite3/graph-analytics"
+	echo "  -w  <string>   : Container name. Default: cxlbench-graph-analytics"
 	echo "  -d  <integer>  : Set the driver memory. Default:64g"
 	echo "  -e  <integer>  : Set the executor memory. Default:64g"
 	echo "  -o  <string>   : Output file to concatenate results to"
@@ -35,20 +35,13 @@ function display_help {
 	exit 0
 }
 
-function run_setup {
-	systemctl start docker
-	docker pull cloudsuite3/graph-analytics
-	docker pull cloudsuite3/twitter-dataset-graph
-	docker create --name graph-data cloudsuite3/twitter-dataset-graph
-}
-
-while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
+while getopts "hp:c:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 	case ${opt} in
 		h)
 			display_help
 			;;
 		p)
-			PRIVILEGED="--privileged --entrypoint /root/entrypoint.sh"
+			PRIVILEGED="--privileged --env NUMA_ARG=$OPTARG"
 			;;
 		c)
 			if [[ $OPTARG =~ ^[0-9]+$ ]]; then
@@ -95,7 +88,7 @@ while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 		a)
 			if [[ $OPTARG =~ ^[0-2]$ ]]; then
 				AUTONUMA_RESTORE=`cat /proc/sys/kernel/numa_balancing`
-				echo $OPTARG > /proc/sys/kernel/numa_balancing
+				echo $OPTARG | sudo tee /proc/sys/kernel/numa_balancing
 			else
 				echo "Error: -a requires a 0,1,or 2."
 				exit 1
@@ -104,7 +97,7 @@ while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 		z)
 			if [[ $OPTARG =~ ^[0-1]$ ]]; then
 				AUTONUMA_DEMOTE_RESTORE=`cat /sys/kernel/mm/numa/demotion_enabled`
-				echo $OPTARG > /sys/kernel/mm/numa/demotion_enabled
+				echo $OPTARG | sudo tee /sys/kernel/mm/numa/demotion_enabled
 			else
 				echo "Error: -z requires a 0 or 1."
 				exit 1
@@ -113,6 +106,7 @@ while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 		t)
 			if [[ $OPTARG =~ ^[0-9]+$ ]]; then
 				start_tiering $OPTARG
+				TIERING_ENABLED="true"
 			else
 				echo "Error: -c option requires an integer argument."
 				exit 1
@@ -138,25 +132,28 @@ done
 rm -rf results
 mkdir -p results
 
-run_setup
+docker create --name graph-data cloudsuite3/twitter-dataset-graph
 
+echo "Test: docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from graph-data $CONTAINER $DMEM $EMEM"
 start_time=$(date +%s%N)
 docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from graph-data $CONTAINER $DMEM $EMEM > results/raw_results.txt
 end_time=$(date +%s%N)
 time_taken=$(echo "scale=9; ($end_time - $start_time)/1000000000" | bc)
 
-echo "graph-analytics,\"$NOTE\",$time_taken," `grep time results/raw_results.txt | sed 's/Running time = //'` >> $RESULTS
+docker rm graph-data
+
+echo "graph-analytics,\"$NOTE\",$time_taken," `grep "Running time" results/raw_results.txt | sed 's/Running time = //'` >> $RESULTS
 
 if [[ -v TIERING_ENABLED ]]; then
 	stop_tiering
 fi
 
 if [[ -v AUTONUMA_DEMOTE_RESTORE ]]; then
-	echo $AUTONUMA_DEMOTE_RESTORE > /sys/kernel/mm/numa/demotion_enabled
+	echo $AUTONUMA_DEMOTE_RESTORE | sudo tee /sys/kernel/mm/numa/demotion_enabled
 fi
 
 if [[ -v AUTONUMA_RESTORE ]]; then
-	echo $AUTONUMA_RESTORE > /proc/sys/kernel/numa_balancing
+	echo $AUTONUMA_RESTORE | sudo tee /proc/sys/kernel/numa_balancing
 fi
 
 echo "completed test"

--- a/benchmarks/cloudsuite3/graph-analytics/run.sh
+++ b/benchmarks/cloudsuite3/graph-analytics/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/cloudsuite3/graph-analytics/testplan.sh
+++ b/benchmarks/cloudsuite3/graph-analytics/testplan.sh
@@ -2,24 +2,24 @@
 #
 ./run.sh -n "Default Settings"
 ./run.sh -c 0 -m 0 -n "cpu=0 mem=0"
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --interleave=0,2" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p -w graph-prefer2
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --weighted-interleave=0,2" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p "--preferred=2"
 ./run.sh -c 0 -m 0,2 -a 1 -z 0 -n "cpu=0 mem=0,2 autonuma=1 demote=0"
 ./run.sh -c 0 -m 0,2 -a 1 -z 1 -n "cpu=0 mem=0,2 autonuma=1 demote=1"
 ./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 autonuma=2 demote=0"
 ./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "cpu=0 mem=0,2 autonuma=2 demote=1"
-./run.sh -c 0 -m 0,2 -a 1 -z 0 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=1 demote=0" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -a 1 -z 1 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=1 demote=1" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=2 demote=0" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=2 demote=1" -p -w graph-interleave
+./run.sh -c 0 -m 0,2 -a 1 -z 0 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=1 demote=0" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 1 -z 1 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=1 demote=1" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=2 demote=0" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=2 demote=1" -p "--weighted-interleave=0,2"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 16384 -n "cpu=0 mem=0,2 tiering 16GB"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 24576 -n "cpu=0 mem=0,2 tiering 24GB"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 32768 -n "cpu=0 mem=0,2 tiering 32GB"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 40960 -n "cpu=0 mem=0,2 tiering 40GB"
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 16384 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 16GB" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 24576 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 24GB" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 32768 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 32GB" -p -w graph-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 40960 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 40GB" -p -w graph-interleave
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 16384 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 16GB" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 24576 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 24GB" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 32768 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 32GB" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 40960 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 40GB" -p "--weighted-interleave=0,2"
 ./run.sh -c 0 -m 0 -s 40g -x 27g -n "cpu=0 mem=0 maxmem=40g swap=0g"
 ./run.sh -c 0 -m 0 -s 40g -x 26g -n "cpu=0 mem=0 maxmem=38g swap=1g"
 ./run.sh -c 0 -m 0 -s 40g -x 24g -n "cpu=0 mem=0 maxmem=36g swap=3g"

--- a/benchmarks/cloudsuite3/inmem-analytics/README.md
+++ b/benchmarks/cloudsuite3/inmem-analytics/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/cloudsuite3/inmem-analytics/README.md
+++ b/benchmarks/cloudsuite3/inmem-analytics/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/cloudsuite3/inmem-analytics/README.md
+++ b/benchmarks/cloudsuite3/inmem-analytics/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docker image used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/cloudsuite3/inmem-analytics/README.md
+++ b/benchmarks/cloudsuite3/inmem-analytics/README.md
@@ -2,9 +2,7 @@
 
 ## Setup
 
-The run script will automatically pull down the default graph analytics image.
-
-If you need an interleave-image, see "Creating interleave images".
+Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 ## Running the test
 
@@ -18,10 +16,10 @@ Some options can be overidden
 Usage: ./run.sh [options]
 Options:
   -h             : Display this help message.
-  -p             : Test requires privilege (interleave container)
+  -p             : Set in-container numactl mempolicy
   -c  <integer>  : CPU NUMA node to bind to
   -m  <int,...>  : Memory NUMA nodes to allow
-  -w  <string>   : Container name. Default: cloudsuite3/in-memory-analytics
+  -w  <string>   : Container name. Default: cxlbench-ima
   -d  <integer>  : Set the driver memory. Default:64g
   -e  <integer>  : Set the executor memory. Default:64g
   -o  <string>   : Output file to concatenate results to
@@ -43,48 +41,12 @@ Included is a sample test plan for a CXL device on NUMA Node 2.
 # Bind the workload to NUMA 0
 ./run.sh -c 0 -m 0 -n "cpu=0 mem=0"
 
-# Interleave the workload between Node 0 and Node 2
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --interleave=0,2" -p -w ima-interleave
+# Interleave the workload between Node 0 and Node 2 with weighted interleave
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --weighted-interleave=0,2" -p "--weighted-interleave=0,2"
 
 # Primarily use NODE 2, but allow non-movable allocations to NODE 0
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p -w ima-prefer2
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p "--preferred=2"
 ```
-
-# NUMACtl Images 
-
-## Creating interleave images
-
-Docker does not allow enabling interleave from outside the container, so software in the container must be changed to invoke numactl --interleave.  These are directions to modify the comatiner image and save a local copy of the modified container image.
-
-Note that these directions assume your interleave settings will be "--interleave=0,2" (NUMA nodes 0 and 2).  You should change this to match your desired settings.
-
-In one terminal:
-1. docker run -it --entrypoint="/bin/bash" cloudsuite3/in-memory-analytics
-2. you'll now be in a copy of the docker container at the bash prompt
-3. apt update
-4. apt install vim numactl
-6. vim /benchmarks/movielens-als/run\_benchmark.sh
-7. change "exec ${SPARK\_HOME}" to "exec numactl --interleave=0,2 ${SPARK\_HOME}"
-8. save and close the document.  do not exit the container yet.
-
-In another terminal:
-1. docker container list
-2. get the container ID for the in-memory-analytics container (e.g. c7b06ce106a0)
-3. docker container commit c7b06ce106a0 ima-interleave
-
-## Create Preferred Node images
-
-Mode CXL memory is onlined as ZONE\_MOVABLE, as a result attempting to run this container 100% out of CXL will probably fail because the kernel will require some ZONE\_NORMAL memory.
-
-To *prefer* node 2 for workload data, follow the interleave image direction, but use --preferred=2 instead of --interleave=0,2.  Then save this image as ima-prefer2.
-
-## Running interleave image
-
-Interleave containers require privilege to run.  To do this, use the -i command to mark the test an interleave test and use -w to replace the container name
-
-Example:
-
-./run -p -c 0 -m 0,2 -w ima-interleave
 
 # Tiering
 

--- a/benchmarks/cloudsuite3/inmem-analytics/README.md
+++ b/benchmarks/cloudsuite3/inmem-analytics/README.md
@@ -63,9 +63,9 @@ In one terminal:
 2. you'll now be in a copy of the docker container at the bash prompt
 3. apt update
 4. apt install vim numactl
-5. vim /benchmarks/run\_benchmark.sh
-6. change "exec ${SPARK\_HOME}" to "exec numactl --interleave=0,2 ${SPARK\_HOME}"
-7. save and close the document.  do not exit the container yet.
+6. vim /benchmarks/movielens-als/run\_benchmark.sh
+7. change "exec ${SPARK\_HOME}" to "exec numactl --interleave=0,2 ${SPARK\_HOME}"
+8. save and close the document.  do not exit the container yet.
 
 In another terminal:
 1. docker container list

--- a/benchmarks/cloudsuite3/inmem-analytics/run.sh
+++ b/benchmarks/cloudsuite3/inmem-analytics/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/cloudsuite3/inmem-analytics/run.sh
+++ b/benchmarks/cloudsuite3/inmem-analytics/run.sh
@@ -10,7 +10,7 @@ MAXMEM=""
 MAXSWAP=""
 DMEM="--driver-memory 64g"
 EMEM="--executor-memory 64g"
-CONTAINER="cloudsuite3/in-memory-analytics"
+CONTAINER="cxlbench-ima"
 PRIVILEGED=""
 RESULTS="results.txt"
 NOTE="Default settings"
@@ -19,10 +19,10 @@ function display_help {
 	echo "Usage: $0 [options]"
 	echo "Options:"
 	echo "  -h             : Display this help message."
-	echo "  -p             : Test requires privilege (interleave container)."
+	echo "  -p             : Set in-container numactl mempolicy"
 	echo "  -c  <integer>  : CPU NUMA node to bind to"
 	echo "  -m  <int,...>  : Memory NUMA nodes to allow"
-	echo "  -w  <string>   : Container name. Default: cloudsuite3/in-memory-analytics"
+	echo "  -w  <string>   : Container name. Default: cxlbench-ima"
 	echo "  -d  <integer>  : Set the driver memory. Default:64g"
 	echo "  -e  <integer>  : Set the executor memory. Default:64g"
 	echo "  -o  <string>   : Output file to concatenate results to"
@@ -35,19 +35,13 @@ function display_help {
 	exit 0
 }
 
-function run_setup {
-	systemctl start docker
-	docker pull cloudsuite3/movielens-dataset
-	docker create --name ima-data cloudsuite3/movielens-dataset
-}
-
-while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
+while getopts "hp:c:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 	case ${opt} in
 		h)
 			display_help
 			;;
 		p)
-			PRIVILEGED="--privileged --entrypoint /root/entrypoint.sh"
+			PRIVILEGED="--privileged --env NUMA_ARG=$OPTARG"
 			;;
 		c)
 			if [[ $OPTARG =~ ^[0-9]+$ ]]; then
@@ -94,7 +88,7 @@ while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 		a)
 			if [[ $OPTARG =~ ^[0-2]$ ]]; then
 				AUTONUMA_RESTORE=`cat /proc/sys/kernel/numa_balancing`
-				echo $OPTARG > /proc/sys/kernel/numa_balancing
+				echo $OPTARG | sudo tee /proc/sys/kernel/numa_balancing
 			else
 				echo "Error: -a requires a 0,1,or 2."
 				exit 1
@@ -103,7 +97,7 @@ while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
 		z)
 			if [[ $OPTARG =~ ^[0-1]$ ]]; then
 				AUTONUMA_DEMOTE_RESTORE=`cat /sys/kernel/mm/numa/demotion_enabled`
-				echo $OPTARG > /sys/kernel/mm/numa/demotion_enabled
+				echo $OPTARG | sudo tee /sys/kernel/mm/numa/demotion_enabled
 			else
 				echo "Error: -z requires a 0 or 1."
 				exit 1
@@ -138,25 +132,27 @@ done
 rm -rf results
 mkdir -p results
 
-run_setup
+docker create --name movielens-data cloudsuite/movielens-dataset
 
 start_time=$(date +%s%N)
-docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from ima-data $CONTAINER /data/ml-latest /data/myratings.csv $DMEM $EMEM > results/raw_results.txt
+docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from movielens-data $CONTAINER /data/ml-latest-small /data/myratings.csv $DMEM $EMEM > results/raw_results.txt
 end_time=$(date +%s%N)
 time_taken=$(echo "scale=9; ($end_time - $start_time)/1000000000" | bc)
 
-echo "in-memory-analytics,\"$NOTE\",$time_taken," `grep time results/raw_results.txt | sed 's/Benchmark execution time: //' | sed 's/ms//'` >> $RESULTS
+docker rm movielens-data
+
+echo "in-memory-analytics,\"$NOTE\",$time_taken," `grep "Benchmark execution time" results/raw_results.txt | sed 's/Benchmark execution time: //' | sed 's/ms//'` >> $RESULTS
 
 if [[ -v TIERING_ENABLED ]]; then
 	stop_tiering
 fi
 
 if [[ -v AUTONUMA_DEMOTE_RESTORE ]]; then
-	echo $AUTONUMA_DEMOTE_RESTORE > /sys/kernel/mm/numa/demotion_enabled
+	echo $AUTONUMA_DEMOTE_RESTORE | sudo tee /sys/kernel/mm/numa/demotion_enabled
 fi
 
 if [[ -v AUTONUMA_RESTORE ]]; then
-	echo $AUTONUMA_RESTORE > /proc/sys/kernel/numa_balancing
+	echo $AUTONUMA_RESTORE | sudo tee /proc/sys/kernel/numa_balancing
 fi
 
 echo "completed test"

--- a/benchmarks/cloudsuite3/inmem-analytics/run.sh
+++ b/benchmarks/cloudsuite3/inmem-analytics/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/cloudsuite3/inmem-analytics/run.sh
+++ b/benchmarks/cloudsuite3/inmem-analytics/run.sh
@@ -37,6 +37,8 @@ function display_help {
 
 function run_setup {
 	systemctl start docker
+	docker pull cloudsuite3/movielens-dataset
+	docker create --name ima-data cloudsuite3/movielens-dataset
 }
 
 while getopts "hpc:m:w:d:e:p:o:n:a:z:t:s:x:" opt; do
@@ -139,7 +141,7 @@ mkdir -p results
 run_setup
 
 start_time=$(date +%s%N)
-docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from data $CONTAINER /data/ml-latest /data/myratings.csv $DMEM $EMEM > results/raw_results.txt
+docker run $PRIVILEGED $MAXMEM $MAXSWAP --ulimit nofile=90000:90000 $CPUSETS_CPU $CPUSETS_MEM --rm --volumes-from ima-data $CONTAINER /data/ml-latest /data/myratings.csv $DMEM $EMEM > results/raw_results.txt
 end_time=$(date +%s%N)
 time_taken=$(echo "scale=9; ($end_time - $start_time)/1000000000" | bc)
 

--- a/benchmarks/cloudsuite3/inmem-analytics/testplan.sh
+++ b/benchmarks/cloudsuite3/inmem-analytics/testplan.sh
@@ -2,26 +2,24 @@
 #
 ./run.sh -n "Default Settings"
 ./run.sh -c 0 -m 0 -n "cpu=0 mem=0"
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --interleave=0,2" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p -w ima-prefer2
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --weighted-interleave=0,2" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p "--preferred=2"
 ./run.sh -c 0 -m 0,2 -a 1 -z 0 -n "cpu=0 mem=0,2 autonuma=1 demote=0"
 ./run.sh -c 0 -m 0,2 -a 1 -z 1 -n "cpu=0 mem=0,2 autonuma=1 demote=1"
-./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 autonuma=2 demote=1"
+./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 autonuma=2 demote=0"
 ./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "cpu=0 mem=0,2 autonuma=2 demote=1"
-./run.sh -c 0 -m 0,2 -a 1 -z 0 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=1 demote=0" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 1 -z 1 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=1 demote=1" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=2 demote=0" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "cpu=0 mem=0,2 --interleave=0,2 autonuma=2 demote=1" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 13312 -n "cpu=0 mem=0,2 tiering 13GB"
+./run.sh -c 0 -m 0,2 -a 1 -z 0 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=1 demote=0" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 1 -z 1 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=1 demote=1" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 2 -z 0 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=2 demote=0" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 autonuma=2 demote=1" -p "--weighted-interleave=0,2"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 16384 -n "cpu=0 mem=0,2 tiering 16GB"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 24576 -n "cpu=0 mem=0,2 tiering 24GB"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 32768 -n "cpu=0 mem=0,2 tiering 32GB"
 ./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 40960 -n "cpu=0 mem=0,2 tiering 40GB"
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 13312 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 13GB" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 16384 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 16GB" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 24576 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 24GB" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 32768 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 32GB" -p -w ima-interleave
-./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 40960 -n "cpu=0 mem=0,2 --interleave=0,2 tiering 40GB" -p -w ima-interleave
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 16384 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 16GB" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 24576 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 24GB" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 32768 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 32GB" -p "--weighted-interleave=0,2"
+./run.sh -c 0 -m 0,2 -a 0 -z 0 -t 40960 -n "cpu=0 mem=0,2 --weighted-interleave=0,2 tiering 40GB" -p "--weighted-interleave=0,2"
 ./run.sh -c 0 -m 0 -s 40g -x 28g -n "cpu=0 mem=0 maxmem=28g swap=0g"
 ./run.sh -c 0 -m 0 -s 40g -x 26g -n "cpu=0 mem=0 maxmem=26g swap=1g"
 ./run.sh -c 0 -m 0 -s 40g -x 24g -n "cpu=0 mem=0 maxmem=24g swap=3g"

--- a/benchmarks/memcached/README.md
+++ b/benchmarks/memcached/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/memcached/README.md
+++ b/benchmarks/memcached/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/memcached/README.md
+++ b/benchmarks/memcached/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docker image used in this benchmark test.
 
 ## Running the test
 

--- a/benchmarks/memcached/README.md
+++ b/benchmarks/memcached/README.md
@@ -1,92 +1,16 @@
-# Building the container
+# Overview
 
-```
-docker pull library/memcached:latest
-docker run -u 0 -it memcached bash
-apt update
-apt install numactl
-```
+## Setup
 
-now in another termianl execute
+Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
-```
-docker container ps
-docker container commit [container-id] memcached-numa
-```
+## Running the test
 
-to run this container we'll need to do the following
+To run a simple test, simply run ./run.sh
 
-```
-docker run -d --privileged -u 11211 -it memcached-numa [ags]
-```
+The default test does not do memory or cpu binding, and sets --driver-memory=64g and --executor-memory=64g (which is enough to prevent OOM issues).
 
-our [args] in this case will be our entire numactl sequence plus the command to launch memcached
-
-```
-docker run -d --privileged -u 11211 -it memcached-numa numactl --interleave=0,2 memcached [memcached-args]
-```
-
-# Building the benchmark
-
-We are going to use memaslap to test our memcached instance, but we'll need to build it since it's not part of the standard build.
-
-```
-wget https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz
-tar -xvzf libmemcached-1.0.18.tar.gz
-cd libmemcached-1.0.18
-```
-
-unfortunately on modern fedora, we need to make a few patches
-
-In clients/memflush.cc, We need to change these NULL pointer checks not to check for a bool
-```
-(base) [root@sr1 libmemcached-1.0.18]# diff clients/memflushx.cc clients/memflush.cc
-42c42
-<   if (opt_servers == false)
----
->   if (!opt_servers)
-51c51
-<     if (opt_servers == false)
----
->     if (!opt_servers)
-```
-
-to clients/memaslap.c we need to add
-```
-/* global structure */
-ms_global_t ms_global;
-
-/* global stats information structure */
-ms_stats_t ms_stats;
-
-/* global statistic structure */
-ms_statistic_t ms_statistic;
-```
-
-to clients/ms\_memslap.h we need to change the similar lines to add extern to them
-```
-/* global structure */
-extern ms_global_t ms_global;
-
-/* global stats information structure */
-extern ms_stats_t ms_stats;
-
-/* global statistic structure */
-extern ms_statistic_t ms_statistic;
-```
-
-// Install dependents for memaslap
-Ubuntu/Debian: $ sudo apt install libevent-dev gcc g++
-RHEL/Fedora/CentOS: $ sudo dnf install libevent-devel gcc g++
-
-now you can build memaslap
-
-```
-./configure --enable-memaslap
-make
-```
-
-# Running the Benchmark
+Some options can be overidden
 
 ```
 Usage: ./run.sh [options]
@@ -95,7 +19,7 @@ Options:
   -p             : Set in-container numactl mempolicy
   -c  <integer>  : CPU NUMA node to bind to
   -m  <int,...>  : Memory NUMA nodes to allow
-  -w  <string>   : Container name. Default: memcached-numa
+  -w  <string>   : Container name. Default: cxlbench-memcached
   -d  <integer>  : Set the data size
   -q  <integer>  : Set the number of threads
   -o  <string>   : Output file to concatenate results to
@@ -113,31 +37,16 @@ example test plan:
 ```
 #!/bin/bash
 
+# Run the workload with no special settings
 ./run.sh -n "Default Settings"
-./run.sh -c 0 -m 0 -n "Bind to Node 0"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -n "Interleave 0,2"
-./run.sh -c 0 -m 0,2 -p "--preferred=2" -n "Preferred 2"
-./run.sh -c 0 -m 0,2 -a 2 -z 1 -n "autonuma=2 demote=1"
-./run.sh -c 0 -m 0,2 -p "--preferred=2" -a 2 -z 1 -n "prefer 2 autonuma=2 demote=1"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -a 2 -z 1 -n "interleave autonuma=2 demote=1"
-./run.sh -c 0 -m 0,2 -t 87040 -n "tier 50:50"
-./run.sh -c 0 -m 0,2 -t 104448 -n "tier 60:40"
-./run.sh -c 0 -m 0,2 -t 121856 -n "tier 70:30"
-./run.sh -c 0 -m 0,2 -t 139264 -n "tier 80:20"
-./run.sh -c 0 -m 0,2 -t 156672 -n "tier 90:10"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -t 87040 -n "intleave tier 50:50"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -t 104448 -n "intleave tier 60:40"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -t 121856 -n "intleave tier 70:30"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -t 139264 -n "intleave tier 80:20"
-./run.sh -c 0 -m 0,2 -p "--interleave=0,2" -t 156672 -n "intleave tier 90:10"
-./run.sh -c 0 -m 0,2 -x 155G -s 256G -n "swap 15GB"
-./run.sh -c 0 -m 0,2 -x 157G -s 256G -n "swap 13GB"
-./run.sh -c 0 -m 0,2 -x 159G -s 256G -n "swap 11GB"
-./run.sh -c 0 -m 0,2 -x 161G -s 256G -n "swap 9GB"
-./run.sh -c 0 -m 0,2 -x 163G -s 256G -n "swap 7GB"
-./run.sh -c 0 -m 0,2 -x 165G -s 256G -n "swap 5GB"
-./run.sh -c 0 -m 0,2 -x 167G -s 256G -n "swap 3GB"
-./run.sh -c 0 -m 0,2 -x 169G -s 256G -n "swap 1GB"
-./run.sh -c 0 -m 0,2 -x 170G -s 256G -n "swap 0GB"
-./run.sh -c 0 -m 0,2 -x 173G -s 256G -n "swap -3GB"
+
+# Bind the workload to NUMA 0
+./run.sh -c 0 -m 0 -n "cpu=0 mem=0"
+
+# Interleave the workload between Node 0 and Node 2 with weighted interleave
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --weighted-interleave=0,2" -p "--weighted-interleave=0,2"
+
+# Primarily use NODE 2, but allow non-movable allocations to NODE 0
+./run.sh -c 0 -m 0,2 -n "cpu=0 mem=0,2 --preferred=2" -p "--preferred=2"
 ```
+

--- a/benchmarks/memcached/README.md
+++ b/benchmarks/memcached/README.md
@@ -31,9 +31,9 @@ docker run -d --privileged -u 11211 -it memcached-numa numactl --interleave=0,2 
 We are going to use memaslap to test our memcached instance, but we'll need to build it since it's not part of the standard build.
 
 ```
-wget https://launchpad.net/libmemcached/1.0/1.0.16/+download/libmemcached-1.0.16.tar.gz
-tar -xvzf libmemcached-1.0.16.tar.gz
-cd libmemcached-1.0.16
+wget https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz
+tar -xvzf libmemcached-1.0.18.tar.gz
+cd libmemcached-1.0.18
 ```
 
 unfortunately on modern fedora, we need to make a few patches
@@ -74,6 +74,10 @@ extern ms_stats_t ms_stats;
 /* global statistic structure */
 extern ms_statistic_t ms_statistic;
 ```
+
+// Install dependents for memaslap
+Ubuntu/Debian: $ sudo apt install libevent-dev gcc g++
+RHEL/Fedora/CentOS: $ sudo dnf install libevent-devel gcc g++
 
 now you can build memaslap
 

--- a/benchmarks/memcached/run.sh
+++ b/benchmarks/memcached/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/memcached/run.sh
+++ b/benchmarks/memcached/run.sh
@@ -7,7 +7,7 @@ CPUSETS_CPU_NODE=""
 CPUSETS_CPU=""
 CPUSETS_MEM=""
 MEMPOLICY=""
-CONTAINER="memcached-numa"
+CONTAINER="cxlbench-memcached"
 RESULTS="results.txt"
 THREADS=""
 NOTE="Default settings"
@@ -21,7 +21,7 @@ function display_help {
 	echo "  -p             : Set in-container numactl mempolicy"
 	echo "  -c  <integer>  : CPU NUMA node to bind to"
 	echo "  -m  <int,...>  : Memory NUMA nodes to allow"
-	echo "  -w  <string>   : Container name. Default: memcached-numa"
+	echo "  -w  <string>   : Container name. Default: cxlbench-memcached"
 	echo "  -d  <integer>  : Set the data size"
 	echo "  -q  <integer>  : Set the number of threads"
 	echo "  -o  <string>   : Output file to concatenate results to"
@@ -41,7 +41,7 @@ while getopts "hc:p:i:d:q:m:w:o:n:a:z:t:s:x:" opt; do
 			display_help
 			;;
 		p)
-			MEMPOLICY="$OPTARG"
+			MEMPOLICY="--env NUMA_ARG=$OPTARG"
 			;;
 		q)
 			THREADS="-P $OPTARG"
@@ -75,7 +75,7 @@ while getopts "hc:p:i:d:q:m:w:o:n:a:z:t:s:x:" opt; do
 		a)
 			if [[ $OPTARG =~ ^[0-2]$ ]]; then
 				AUTONUMA_RESTORE=`cat /proc/sys/kernel/numa_balancing`
-				echo $OPTARG > /proc/sys/kernel/numa_balancing
+				echo $OPTARG | sudo tee /proc/sys/kernel/numa_balancing
 			else
 				echo "Error: -a requires a 0,1,or 2."
 				exit 1
@@ -84,7 +84,7 @@ while getopts "hc:p:i:d:q:m:w:o:n:a:z:t:s:x:" opt; do
 		z)
 			if [[ $OPTARG =~ ^[0-1]$ ]]; then
 				AUTONUMA_DEMOTE_RESTORE=`cat /sys/kernel/mm/numa/demotion_enabled`
-				echo $OPTARG > /sys/kernel/mm/numa/demotion_enabled
+				echo $OPTARG | sudo tee /sys/kernel/mm/numa/demotion_enabled
 			else
 				echo "Error: -z requires a 0 or 1."
 				exit 1
@@ -122,16 +122,18 @@ done
 rm -rf results
 mkdir -p results
 
-docker run --name memcached-docker -d --privileged $MAXMEM $MAXSWAP $CPUSETS_CPU $CPUSETS_MEM -p 11211:11211 -u 11211 -it $CONTAINER numactl $MEMPOLICY memcached -m 262144
+
+docker run --name memcached-docker -d --privileged $MEMPOLICY $MAXMEM $MAXSWAP $CPUSETS_CPU $CPUSETS_MEM --network=host -u 11211 -it $CONTAINER -m 262144
 sleep 1
 
 start_time=$(date +%s%N)
-numactl --cpunodebind 1 ./libmemcached-1.0.18/clients/memaslap -s 127.0.0.1:11211 -T 16 -c 256 -t 180s -X 131072 > results/raw_results.txt
+docker run --name memaslap-docker --privileged $CPUSETS_CPU --network=host cxlbench-memaslap -s 127.0.0.1:11211 -T 16 -c 256 -t 180s -X 131072 > results/raw_results.txt
 end_time=$(date +%s%N)
 time_taken=$(echo "scale=9; ($end_time - $start_time)/1000000000" | bc)
 
 docker container stop memcached-docker
 docker container rm memcached-docker
+docker container rm memaslap-docker
 
 echo "memcached,\"$NOTE\",$time_taken" >> $RESULTS
 cat results/raw_results.txt | grep "Run time" >> $RESULTS
@@ -141,11 +143,11 @@ if [[ -v TIERING_ENABLED ]]; then
 fi
 
 if [[ -v AUTONUMA_DEMOTE_RESTORE ]]; then
-	echo $AUTONUMA_DEMOTE_RESTORE > /sys/kernel/mm/numa/demotion_enabled
+	echo $AUTONUMA_DEMOTE_RESTORE | sudo tee /sys/kernel/mm/numa/demotion_enabled
 fi
 
 if [[ -v AUTONUMA_RESTORE ]]; then
-	echo $AUTONUMA_RESTORE > /proc/sys/kernel/numa_balancing
+	echo $AUTONUMA_RESTORE | sudo tee /proc/sys/kernel/numa_balancing
 fi
 
 echo "completed test"

--- a/benchmarks/memcached/run.sh
+++ b/benchmarks/memcached/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/redis/README.md
+++ b/benchmarks/redis/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docker image used in this benchmark test.
 
 # Running the benchmark
 

--- a/benchmarks/redis/README.md
+++ b/benchmarks/redis/README.md
@@ -1,41 +1,8 @@
 # Container setup
 
-pull down and run the latest container
-```
-docker pull redis:latest
-docker run -it --entrypoint="/bin/bash" redis
-```
+## Setup
 
-in the container
-```
-apt update
-apt install vim numactl redis-server
-cd /root/
-```
-
-in the root directory add the following files:
-
-entrypoint.sh
-```
-numactl $1 redis-server /root/redis.conf --port 7551
-```
-
-redis.conf
-(included in this directory)
-this config does three things
-- Binds to port 7551
-- Sets IP binding to 0.0.0.0 (accepts from anywhere)
-- turns protected mode off (otherwise connections will fail)
-- turns snapshotting off (for consistency of performance)
-
-
-
-In a separate console, commit the container
-
-```
-docker container ps
-docker container commit [container-id] redis-numa
-```
+Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 # Running the benchmark
 
@@ -52,7 +19,7 @@ Options:
   -p             : Set in-container numactl mempolicy
   -c  <integer>  : CPU NUMA node to bind to
   -m  <int,...>  : Memory NUMA nodes to allow
-  -w  <string>   : Container name. Default: redis-numa
+  -w  <string>   : Container name. Default: cxlbench-redis
   -d  <integer>  : Set the data size
   -q  <integer>  : Set the number of threads
   -o  <string>   : Output file to concatenate results to

--- a/benchmarks/redis/README.md
+++ b/benchmarks/redis/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](../../../tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
 
 # Running the benchmark
 

--- a/benchmarks/redis/README.md
+++ b/benchmarks/redis/README.md
@@ -2,7 +2,7 @@
 
 pull down and run the latest container
 ```
-docker pull redis/redis:latest
+docker pull redis:latest
 docker run -it --entrypoint="/bin/bash" redis
 ```
 
@@ -34,7 +34,7 @@ In a separate console, commit the container
 
 ```
 docker container ps
-docker conatiner commit [container-id] redis-numa
+docker container commit [container-id] redis-numa
 ```
 
 # Running the benchmark

--- a/benchmarks/redis/README.md
+++ b/benchmarks/redis/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr iamge used in this benchmark test.
+Use the tools/docker_prep [README](/tools/docker_prep/README) to stage the docekr image used in this benchmark test.
 
 # Running the benchmark
 

--- a/benchmarks/redis/parse_results.py
+++ b/benchmarks/redis/parse_results.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-f = open("results.txt","r");
-lines = f.readlines();
+f = open("results.txt","r")
+lines = f.readlines()
 f.close()
 
 header = ""

--- a/benchmarks/redis/run.sh
+++ b/benchmarks/redis/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/redis/run.sh
+++ b/benchmarks/redis/run.sh
@@ -7,7 +7,7 @@ CPUSETS_CPU_NODE=""
 CPUSETS_CPU=""
 CPUSETS_MEM=""
 MEMPOLICY=""
-CONTAINER="redis-numa"
+CONTAINER="cxlbench-redis"
 RESULTS="results.txt"
 DSIZE=""
 THREADS=""
@@ -22,7 +22,7 @@ function display_help {
 	echo "  -p             : Set in-container numactl mempolicy"
 	echo "  -c  <integer>  : CPU NUMA node to bind to"
 	echo "  -m  <int,...>  : Memory NUMA nodes to allow"
-	echo "  -w  <string>   : Container name. Default: redis-numa"
+	echo "  -w  <string>   : Container name. Default: cxlbench-redis"
 	echo "  -d  <integer>  : Set the data size"
 	echo "  -q  <integer>  : Set the number of threads"
 	echo "  -o  <string>   : Output file to concatenate results to"
@@ -41,7 +41,7 @@ while getopts "hc:p:i:d:q:m:w:o:n:a:z:t:s:x:" opt; do
 			display_help
 			;;
 		p)
-			MEMPOLICY="$OPTARG"
+			MEMPOLICY="--env NUMA_ARG=$OPTARG"
 			;;
 		d)
 			DSIZE="-d $OPTARG"
@@ -78,7 +78,7 @@ while getopts "hc:p:i:d:q:m:w:o:n:a:z:t:s:x:" opt; do
 		a)
 			if [[ $OPTARG =~ ^[0-2]$ ]]; then
 				AUTONUMA_RESTORE=`cat /proc/sys/kernel/numa_balancing`
-				echo $OPTARG > /proc/sys/kernel/numa_balancing
+				echo $OPTARG | sudo tee /proc/sys/kernel/numa_balancing
 			else
 				echo "Error: -a requires a 0,1,or 2."
 				exit 1
@@ -87,7 +87,7 @@ while getopts "hc:p:i:d:q:m:w:o:n:a:z:t:s:x:" opt; do
 		z)
 			if [[ $OPTARG =~ ^[0-1]$ ]]; then
 				AUTONUMA_DEMOTE_RESTORE=`cat /sys/kernel/mm/numa/demotion_enabled`
-				echo $OPTARG > /sys/kernel/mm/numa/demotion_enabled
+				echo $OPTARG | sudo tee /sys/kernel/mm/numa/demotion_enabled
 			else
 				echo "Error: -z requires a 0 or 1."
 				exit 1
@@ -125,15 +125,17 @@ done
 rm -rf results
 mkdir -p results
 
-docker run --name redis-docker -d --privileged $MAXMEM $MAXSWAP $CPUSETS_CPU $CPUSETS_MEM -p 7551:7551 --entrypoint="/root/entrypoint.sh" $CONTAINER "$MEMPOLICY"
+docker run --name redis-docker -d --privileged $MEMPOLICY $MAXMEM $MAXSWAP $CPUSETS_CPU $CPUSETS_MEM --network=host $CONTAINER 
+sleep 1
 
 start_time=$(date +%s%N)
-redis-benchmark -p 7551 -t GET,SET,LPUSH,LRANGE_100 --csv $DSIZE $THREADS > results/raw_results.txt
+docker run --name redis-benchmark --network=host --entrypoint=/usr/local/bin/redis-benchmark $CONTAINER  -p 7551 -t GET,SET,LPUSH,LRANGE_100 --csv $DSIZE $THREADS > results/raw_results.txt
 end_time=$(date +%s%N)
 time_taken=$(echo "scale=9; ($end_time - $start_time)/1000000000" | bc)
 
 docker container stop redis-docker
 docker container rm redis-docker
+docker container rm redis-benchmark
 
 echo "redis,\"$NOTE\",$time_taken" >> $RESULTS
 cat results/raw_results.txt >> $RESULTS
@@ -143,11 +145,11 @@ if [[ -v TIERING_ENABLED ]]; then
 fi
 
 if [[ -v AUTONUMA_DEMOTE_RESTORE ]]; then
-	echo $AUTONUMA_DEMOTE_RESTORE > /sys/kernel/mm/numa/demotion_enabled
+	echo $AUTONUMA_DEMOTE_RESTORE | sudo tee /sys/kernel/mm/numa/demotion_enabled
 fi
 
 if [[ -v AUTONUMA_RESTORE ]]; then
-	echo $AUTONUMA_RESTORE > /proc/sys/kernel/numa_balancing
+	echo $AUTONUMA_RESTORE | sudo tee /proc/sys/kernel/numa_balancing
 fi
 
 echo "completed test"

--- a/benchmarks/redis/run.sh
+++ b/benchmarks/redis/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 if [[ -f ./setup_env.sh ]]; then
 	source ./setup_env.sh
 fi

--- a/benchmarks/tpcc/README.md
+++ b/benchmarks/tpcc/README.md
@@ -67,19 +67,20 @@ The script requires the following commands and utilities to be installed
 - sed
 - awk
 - podman
+- dstat
 
 To install these prerequsites, use:
 
 **Fedora/CentOS/RHEL**
 
 ```bash
-$ sudo dnf install numactl sed gawk podman util-linux pciutils
+$ sudo dnf install numactl sed gawk podman util-linux pciutils dstat
 ```
 
 **Ubuntu**
 
 ```bash
-$ sudo apt install numactl grep sed gawk podman util-linux pciutils
+$ sudo apt install numactl grep sed gawk podman util-linux pciutils dstat
 ```
 
 ### MySQL Data Directory

--- a/tools/docker_prep/Dockerfile.graph
+++ b/tools/docker_prep/Dockerfile.graph
@@ -1,0 +1,19 @@
+FROM cloudsuite/graph-analytics
+
+## install build tool
+RUN apt update || true
+RUN apt install -y git make autoconf libtool
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+## insert numactl into entrypoint
+WORKDIR /
+RUN sed -i 's/${SPARK_HOME}/numactl ${NUMA_ARG} ${SPARK_HOME}/' /root/run_benchmark.sh

--- a/tools/docker_prep/Dockerfile.ima
+++ b/tools/docker_prep/Dockerfile.ima
@@ -1,0 +1,19 @@
+FROM cloudsuite/in-memory-analytics
+
+## install build tool
+RUN apt update || true
+RUN apt install -y git make autoconf libtool
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+## insert numactl into entrypoint
+WORKDIR /
+RUN sed -i 's/${SPARK_HOME}/numactl ${NUMA_ARG} ${SPARK_HOME}/' /root/run_benchmark.sh

--- a/tools/docker_prep/Dockerfile.memaslap
+++ b/tools/docker_prep/Dockerfile.memaslap
@@ -1,0 +1,48 @@
+FROM ubuntu:24.04
+
+## install build tool
+RUN apt update && apt install -y wget libevent-dev gcc g++ git make autoconf libtool
+
+## get the source code
+RUN wget https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz
+RUN tar -xvzf libmemcached-1.0.18.tar.gz -C /
+WORKDIR /libmemcached-1.0.18
+
+## patch a few locations
+RUN sed -i "s/opt_servers == false/\!opt_servers/g" clients/memflush.cc
+RUN sed -i '48 i /* global structure */\
+ms_global_t ms_global;\
+\
+/* global stats information structure */\
+ms_stats_t ms_stats;\
+\
+/* global statistic structure */\
+ms_statistic_t ms_statistic;\
+' clients/memaslap.c
+RUN sed -i "s/ms_global_t ms_global/extern ms_global_t ms_global/" clients/ms_memslap.h
+RUN sed -i "s/ms_stats_t ms_stats/extern ms_stats_t ms_stats/" clients/ms_memslap.h
+RUN sed -i "s/ms_statistic_t ms_statistic/extern ms_statistic_t ms_statistic/" clients/ms_memslap.h
+
+## make memaslap
+RUN ./configure --enable-memaslap
+RUN make
+
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure --enable-static
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+# Build a shell script because the ENTRYPOINT cannot use ENV and CMD at the same time
+# numactl --cpunodebind 1 ./libmemcached-1.0.18/clients/memaslap -s 127.0.0.1:11211 -T 16 -c 256 -t 180s -X 131072 > results/raw_results.txt
+ENV entryscript='#!/bin/bash \n numactl ${NUMA_ARG} /libmemcached-1.0.18/clients/memaslap "$@"'
+RUN echo "$entryscript" > ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+# Run the generated shell script.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tools/docker_prep/Dockerfile.memcached
+++ b/tools/docker_prep/Dockerfile.memcached
@@ -1,0 +1,23 @@
+FROM debian AS numa_build
+
+## install build tool
+RUN apt update && apt install -y git make autoconf libtool
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure --enable-static
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+FROM library/memcached:latest
+
+COPY --from=numa_build /numactl /numactl
+
+## insert numactl into entrypoint
+USER root
+RUN sed -i 's,exec,exec ./numactl/numactl ${NUMA_ARG},g' /usr/local/bin/docker-entrypoint.sh
+USER memcache

--- a/tools/docker_prep/Dockerfile.mlc
+++ b/tools/docker_prep/Dockerfile.mlc
@@ -1,0 +1,28 @@
+FROM debian:12-slim
+
+## install build tool
+RUN apt update && apt install -y wget git make autoconf libtool
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure --enable-static
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+## get MLC to /local
+COPY ../../benchmarks/IntelMLC/get_mlc.sh /local/get_mlc.sh
+WORKDIR /local
+RUN ./get_mlc.sh
+
+
+# Build a shell script because the ENTRYPOINT cannot use ENV and CMD at the same time
+ENV entryscript='#!/bin/bash \n numactl ${NUMA_ARG} ./mlc "$@"'
+RUN echo "$entryscript" > ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+# Run the generated shell script.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tools/docker_prep/Dockerfile.qdrant
+++ b/tools/docker_prep/Dockerfile.qdrant
@@ -1,0 +1,17 @@
+FROM qdrant/qdrant
+
+## install build tool
+RUN apt update && apt install -y git make autoconf libtool
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure --enable-static
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+## insert numactl into entrypoint
+WORKDIR /qdrant
+RUN sed -i 's,./qdrant,numactl ${NUMA_ARG} ./qdrant,g' entrypoint.sh

--- a/tools/docker_prep/Dockerfile.redis
+++ b/tools/docker_prep/Dockerfile.redis
@@ -1,0 +1,25 @@
+FROM redis:latest
+
+COPY ../../benchmarks/redis/redis.conf /root/redis.conf
+
+## install build tool
+RUN apt update && apt install -y git make autoconf libtool redis-server
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure --enable-static
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+# Build a shell script because the ENTRYPOINT cannot use ENV and CMD at the same time
+WORKDIR /root
+ENV entryscript='#!/bin/bash \n numactl ${NUMA_ARG} redis-server /root/redis.conf --port 7551 "$@" \n sleep infinity'
+RUN echo "$entryscript" > ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+# Run the generated shell script.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tools/docker_prep/Dockerfile.stream
+++ b/tools/docker_prep/Dockerfile.stream
@@ -1,0 +1,29 @@
+FROM debian:12-slim
+
+## install build tool
+RUN apt update && apt install -y wget git make autoconf libtool
+
+## build latest numactl
+RUN git clone --depth=1 https://github.com/numactl/numactl /numactl
+WORKDIR /numactl
+RUN ./autogen.sh
+RUN ./configure --enable-static
+RUN make
+RUN make install
+RUN cp ./.libs/libnuma.so.1 /lib/x86_64-linux-gnu/
+
+
+## get MLC to /local
+COPY ../../benchmarks/stream /stream 
+WORKDIR /stream
+RUN sed -i 's,.exe,,g' Makefile
+RUN make stream_c
+
+
+# Build a shell script because the ENTRYPOINT cannot use ENV and CMD at the same time
+ENV entryscript='#!/bin/bash \n numactl ${NUMA_ARG} ./stream_c "$@"'
+RUN echo "$entryscript" > ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+# Run the generated shell script.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tools/docker_prep/README
+++ b/tools/docker_prep/README
@@ -1,0 +1,32 @@
+# ABOUT
+
+This tool is to pull and build all the docker images used in the cxlbench.  
+Each image will build the numactl from its github source to support weighted interleave.  
+
+## BUILD_ALL
+
+```bash
+docker compose build -f compose.yaml
+```
+
+## Build Individual Image
+
+```bash
+docker build -f Dockerfile.mlc -t cxlbench-mlc ../../
+docker build -f Dockerfile.graph -t  cxlbench-graph-analytics .
+docker build -f Dockerfile.ima -t cxlbench-ima .
+docker build -f Dockerfile.memcached -t cxlbench-memcached .
+docker build -f Dockerfile.memaslap -t cxlbench-memaslap .
+docker build -f Dockerfile.qdrant -t cxlbench-qdrant .
+docker build -f Dockerfile.redis -t cxlbench-redis ../../
+docker build -f Dockerfile.stream -t cxlbench-stream ../../
+```
+
+## Usage
+
+Numactl parameter is passed in via environment variable NUMA_ARG, and test argument is passed in after the image.  
+For example, run mlc with numactl option "--membind=0" and mlc argument "--max_bandwidth":
+
+```bash
+docker run --privileged --env NUMA_ARG="--membind=0" cxlbench.mlc --max_bandwidth
+```

--- a/tools/docker_prep/compose.yaml
+++ b/tools/docker_prep/compose.yaml
@@ -1,0 +1,35 @@
+name: cxlbench
+
+services:
+  mlc:
+    build:
+      context: ../../
+      dockerfile: ./tools/docker_prep/Dockerfile.mlc
+  graph-analytics:
+    build:
+      context: .
+      dockerfile: Dockerfile.graph
+  ima:
+    build:
+      context: .
+      dockerfile: Dockerfile.ima
+  memcached:
+    build:
+      context: .
+      dockerfile: Dockerfile.memcached
+  memaslap:
+    build:
+      context: .
+      dockerfile: Dockerfile.memaslap
+  qdrant:
+    build:
+      context: .
+      dockerfile: Dockerfile.qdrant
+  redis:
+    build:
+      context: ../../
+      dockerfile: ./tools/docker_prep/Dockerfile.redis
+  stream:
+    build:
+      context: ../../
+      dockerfile: ./tools/docker_prep/Dockerfile.stream


### PR DESCRIPTION
This PR adds a tool to create docker images through docker compose for each benchmark test with latest numactl which supports weighted interleave. All the docker images now have unified method to pass in the numactl parameters. Current benchmark graph-analytics, inmem-analytics, memcached and redis test run scripts have been modified to use the corresponding docker image. 
